### PR TITLE
ci: add test, vet, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  reviewers:
+    - "brandonldixon"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  reviewers:
+    - "brandonldixon"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+on: [ push, pull_request ]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Build
+        run: go build
+      - name: Vet
+        run: go vet
+


### PR DESCRIPTION
Use CI to ensure code builds, use `go vet` to ensure the code looks good, enable Dependabot for updates to Go modules and CI components.
